### PR TITLE
iphotoexport: boneyard

### DIFF
--- a/iphotoexport.rb
+++ b/iphotoexport.rb
@@ -1,0 +1,18 @@
+require 'formula'
+
+class Iphotoexport < Formula
+  homepage 'http://code.google.com/p/iphotoexport/'
+  url 'https://iphotoexport.googlecode.com/files/iphotoexport-1.6.4.zip'
+  sha1 '50fa0916cf9689efdfd33cd4680424234b4e9023'
+
+  depends_on 'exiftool'
+
+  def install
+    unzip_dir = "#{name}-#{version}"
+    # Change hardcoded exiftool path
+    inreplace "#{unzip_dir}/tilutil/exiftool.py", "/usr/bin/exiftool", "exiftool"
+
+    prefix.install Dir["#{unzip_dir}/*"]
+    bin.install_symlink prefix+'iphotoexport.py' => 'iphotoexport'
+  end
+end


### PR DESCRIPTION
This was replaced by PhoShare in 2010, and PhoShare [ceased development in 2012](https://groups.google.com/forum/?fromgroups=#!topic/phoshare-users/moWsMcD5SdQ).