### PR TITLE
dupx: evict from core

### DIFF
--- a/dupx.rb
+++ b/dupx.rb
@@ -1,0 +1,12 @@
+require 'formula'
+
+class Dupx < Formula
+  homepage 'http://www.isi.edu/~yuri/dupx/'
+  url 'http://www.isi.edu/~yuri/dupx/dupx-0.1.tar.gz'
+  sha1 '69cac2bacc9aefff59e84d5bfd053f01c1bc7551'
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make install"
+  end
+end


### PR DESCRIPTION
dupx has GDB as a build requirement, but GDB lives in the homebrew/dupes tap now, so dupx cannot stay in core.