### PR TITLE
gccxml: boneyard

### DIFF
--- a/gccxml.rb
+++ b/gccxml.rb
@@ -1,0 +1,11 @@
+class Gccxml < Formula
+  homepage "https://gccxml.github.io/"
+  head "https://github.com/gccxml/gccxml.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
GCCXML was superseded by CastXML.
It will not compile with clang and is not maintained.

Do not try to revive this formula, it is here only for historical reasons.

This formula was removed from homebrew/homebrew-head-only:
https://github.com/Homebrew/homebrew-head-only/pull/203