### PR TITLE
Update doco for core/formula split

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ brew install https://raw.githubusercontent.com/Homebrew/homebrew-boneyard/master
 ```
 
 ## Documentation
-`brew help`, `man brew` or check [Homebrew's documentation](https://github.com/Homebrew/homebrew/tree/master/share/doc/homebrew#readme).
+`brew help`, `man brew` or check [Homebrew's documentation](https://github.com/Homebrew/brew/tree/master/share/doc/homebrew#readme).


### PR DESCRIPTION
Updates link to the main README.

I looked through the stuff under `cmd/` and didn't see anything there that needed updating, so I think this gets the boneyard repo up to date for core/formula split.