### PR TITLE
tevent: migrate from core

### DIFF
--- a/tevent.rb
+++ b/tevent.rb
@@ -1,0 +1,17 @@
+class Tevent < Formula
+  desc "Event system based on the talloc memory management library"
+  homepage "https://tevent.samba.org/"
+  url "https://www.samba.org/ftp/tevent/tevent-0.9.21.tar.gz"
+  sha256 "f2be7463573dab2d8210cb57fe7e7e2aeb323274cbdc865a6e29ddcfb977f0f4"
+
+  depends_on "pkg-config" => :build
+  depends_on "talloc"
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-rpath",
+                          "--without-gettext",
+                          "--bundled-libraries=!talloc"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/6607.

Created with `brew boneyard-formula-pr` because it has zero installs.