### PR TITLE
fix pathname: prepend 'u' before 'niverse'

### DIFF
--- a/electric-fence.rb
+++ b/electric-fence.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class ElectricFence < Formula
   homepage "http://perens.com/FreeSoftware/ElectricFence/"
-  url "http://old-releases.ubuntu.com/ubuntu/pool/niverse/e/electric-fence/electric-fence_2.1.13-0.1.tar.gz"
+  url "http://old-releases.ubuntu.com/ubuntu/pool/universe/e/electric-fence/electric-fence_2.1.13-0.1.tar.gz"
   version "2.1.13-0.1"
   sha256 "60002eaae3d94fa68e9a42778a264e945b343328d22beb105c6ef726377492d7"
 


### PR DESCRIPTION
`http://old-releases.ubuntu.com/ubuntu/pool/niverse/e/electric-fence/electric-fence_2.1.13-0.1.tar.gz` misses the 'u' of 'universe'.