### PR TITLE
dmtx-utils: migrate from core

### DIFF
--- a/dmtx-utils.rb
+++ b/dmtx-utils.rb
@@ -1,0 +1,17 @@
+class DmtxUtils < Formula
+  desc "Read and write data matrix barcodes"
+  homepage "http://www.libdmtx.org"
+  url "https://downloads.sourceforge.net/project/libdmtx/libdmtx/0.7.4/dmtx-utils-0.7.4.zip"
+  sha256 "4e8be16972320a64351ab8d57f3a65873a1c35135666a9ce5fd574b8dc52078f"
+  revision 2
+
+  depends_on "pkg-config" => :build
+  depends_on "libdmtx"
+  depends_on "imagemagick"
+
+  def install
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/8740.

Created with `brew boneyard-formula-pr` because it's marked as abandoned on SourceForge and because upstream has not responded to the report of Imagemagick 7 problems for over 6 months.