### PR TITLE
ngrok: remove a deprecation warning

### DIFF
--- a/ngrok.rb
+++ b/ngrok.rb
@@ -19,7 +19,7 @@ class Ngrok < Formula
   end
 
   def install
-    ENV.j1
+    ENV.deparallelize
     system "make", "release-client"
     bin.install "bin/ngrok"
   end


### PR DESCRIPTION
Got this warning when installing ngrok:

```
Warning: Calling ENV.j1 is deprecated!
Use ENV.deparallelize instead.
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-boneyard/ngrok.rb:22:in `install'
Please report this to the homebrew/boneyard tap!
```

So I'm reporting.