### PR TITLE
memcachedb: fix download url

### DIFF
--- a/memcachedb.rb
+++ b/memcachedb.rb
@@ -1,9 +1,9 @@
 class Memcachedb < Formula
   homepage "http://memcachedb.org"
-  url "https://memcachedb.googlecode.com/files/memcachedb-1.2.1-beta.tar.gz"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/memcachedb/memcachedb-1.2.1-beta.tar.gz"
   sha256 "5af99f7970ab71ba287ba9bab61d4c36b69acf290a21f10e0dd1f64b82a9d403"
 
-  depends_on "berkeley-db4"
+  depends_on "berkeley-db@4"
   depends_on "libevent"
 
   def install


### PR DESCRIPTION
* Google Code shut down January 25, 2016.
* Fixed BDB dependency naming.