### PR TITLE
bip: migrate from core

### DIFF
--- a/bip.rb
+++ b/bip.rb
@@ -1,0 +1,31 @@
+class Bip < Formula
+  desc "IRC proxy"
+  homepage "https://bip.milkypond.org" # Self-signed cert.
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/b/bip/bip_0.8.9.orig.tar.gz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/b/bip/bip_0.8.9.orig.tar.gz"
+  sha256 "3c950f71ef91c8b686e6835f9b722aa7ccb88d3da4ec1af19617354fd3132461"
+  revision 1
+
+  depends_on "openssl"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}/bip"
+
+    system "make", "install"
+    (etc/"bip").install "samples/bip.conf"
+  end
+
+  def caveats; <<-EOS.undent
+    Prior to running bip you will need to do:
+      mkdir -p ~/.bip/logs
+    EOS
+  end
+
+  test do
+    system bin/"bip", "-v"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/10127.

Created with `brew boneyard-formula-pr` because the homepage is self signed and there were only 2 installs in the last month.