### PR TITLE
edelta: migrate from core

### DIFF
--- a/edelta.rb
+++ b/edelta.rb
@@ -1,0 +1,18 @@
+class Edelta < Formula
+  desc "XDelta-style binary differ"
+  homepage "http://www.diku.dk/hjemmesider/ansatte/jacobg/edelta/"
+  url "http://www.diku.dk/hjemmesider/ansatte/jacobg/edelta/edelta-0.10b.tar.gz"
+  sha256 "86d60b8726d37d5486b0d8030492a99b2f4ce1266ad50a99edb07ee6d529815e"
+
+  def install
+    system "make", "CFLAGS=#{ENV.cflags}"
+    bin.install "edelta"
+  end
+
+  test do
+    (testpath/"test1").write "foo"
+    (testpath/"test2").write "bar"
+
+    system "#{bin}/edelta", "delta", "test1", "test2"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/10128.

Created with `brew boneyard-formula-pr` because the upstream homepage is gone and there were zero installs in the last month.