### PR TITLE
probatron4j: migrate from core

### DIFF
--- a/probatron4j.rb
+++ b/probatron4j.rb
@@ -1,0 +1,13 @@
+class Probatron4j < Formula
+  desc "Schematron validator (use with Java 1.5 or later)"
+  homepage "http://www.probatron.org"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/probatron4j/probatron4j-0.7.4.zip"
+  sha256 "53f1d28d5adbc0abe8a12015a4da3a2da000e56cb1328212870d0e6fe4fe941c"
+
+  bottle :unneeded
+
+  def install
+    libexec.install "probatron.jar", "notices"
+    bin.write_jar_script libexec/"probatron.jar", "probatron"
+  end
+end


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/10197.

Created with `brew boneyard-formula-pr` because the homepage is gone and 1 install in the last 30 days.